### PR TITLE
Task/29 update filecoin upload functions enabling withcdn flag 

### DIFF
--- a/helpers/porUpload.js
+++ b/helpers/porUpload.js
@@ -53,6 +53,7 @@ class PorUploader {
     this.synapse = await Synapse.create({
       privateKey: privateKey,
       rpcURL: rpcURL,
+      withCDN: true,
     });
     console.log("✅ SDK initialized");
   }

--- a/helpers/projectUpload.js
+++ b/helpers/projectUpload.js
@@ -52,6 +52,7 @@ export class ProjectUploader {
       this.synapse = await Synapse.create({
         privateKey: privateKey,
         rpcURL: rpcURL,
+        withCDN: true,
       });
       this.context = await this.synapse.storage.createContext();
     } catch (error) {


### PR DESCRIPTION
This PR introduces the withCDN flag in synapse sdk initialization process, enabling filecoin download via the public Filecoin Beam url.

>this.synapse = await Synapse.create({ privateKey: privateKey, rpcURL: rpcURL, withCDN: true, });

closes #29 