### PR TITLE
changed the cookie sameSite policy

### DIFF
--- a/app/backend/src/routes/userRoutes.js
+++ b/app/backend/src/routes/userRoutes.js
@@ -17,12 +17,16 @@ const User = require("../models/User");
 const router = express.Router();
 
 // Cookie configuration
-const getCookieOptions = () => ({
-  httpOnly: true,
-  secure: process.env.NODE_ENV === "production", // HTTPS only in production
-  sameSite: "strict",
-  maxAge: 7 * 24 * 60 * 60 * 1000, // 7 days
-});
+const getCookieOptions = () => {
+  const isProduction = process.env.NODE_ENV === "production";
+  const isSameDomain = process.env.SAME_DOMAIN === "true";
+  return {
+    httpOnly: true,
+    secure: isProduction, // HTTPS only in production
+    sameSite: isProduction && !isSameDomain ? "none" : "strict",
+    maxAge: 7 * 24 * 60 * 60 * 1000, // 7 days
+  };
+};
 
 // @desc    User signup (public registration)
 // @route   POST /api/v1/users/signup


### PR DESCRIPTION
This pull request updates the cookie configuration logic in `userRoutes.js` to better handle deployment scenarios where the frontend and backend may be on the same or different domains. The main change is making the `sameSite` attribute dynamic based on environment variables.

**Cookie configuration improvements:**

* Updated `getCookieOptions` to set the `sameSite` attribute to `"none"` when running in production and the frontend and backend are on different domains, otherwise defaults to `"strict"`. This is controlled by the new `SAME_DOMAIN` environment variable.
* Refactored the function to use variables for clarity and maintainability, and to ensure secure cookie handling in various deployment environments.